### PR TITLE
Quiet push

### DIFF
--- a/_deploy.sh
+++ b/_deploy.sh
@@ -14,4 +14,4 @@ git rm -rf .
 cp -r ../public/* ./
 git add --all *
 git commit -m "Update curso-r" || true
-git push origin gh-pages
+git push -q origin gh-pages


### PR DESCRIPTION
This is actually very important for security reasons. It was totally my fault forgetting to add `-q` in the initial version of `_deploy.sh` in the bookdown-demo repo. You are strongly recommended to delete your existing PAT on Github and generate a new one.

Apologies and thanks!